### PR TITLE
Fix typo in documentation for connected_components example

### DIFF
--- a/_docs/running-the-example.md
+++ b/_docs/running-the-example.md
@@ -83,7 +83,7 @@ anymore:
 
 ```
 INFO:…: QueryId(0) | Disconnecting randomly chosen switch #149
-INFO:…: QueryId(1) | The are now 2 disconnected partitions in the graph!
+INFO:…: QueryId(1) | There are now 2 disconnected partitions in the graph!
 ```
 
 Note that the simulated fault is only temporary. After 10 seconds, the


### PR DESCRIPTION
Good evening guys,

This PR fixes a typo in the documentation for the connected_components example. The corresponding PR on the strymon-core repo can be found at https://github.com/strymon-system/strymon-core/pull/1 .

Best wishes,
Matt

Signed-off-by: Matthew Forshaw <matthewforshaw@gmail.com>