### PR TITLE
Submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "submodules/snailtrail"]
+	path = submodules/snailtrail
+	url = https://github.com/strymon-system/snailtrail.git

--- a/_config.yml
+++ b/_config.yml
@@ -102,3 +102,4 @@ exclude:
   - Gemfile
   - Gemfile.lock
   - vendor
+  - submodules

--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,7 @@ future: false
 collections:
   docs:
     output: true
-    permalink: /:collection/:name
+    permalink: /:collection/:path
 
 # THEME-SPECIFIC CONFIGURATION
 theme_settings:


### PR DESCRIPTION
This PR adds submodules to other repositories. This will allow us to use symlinks to link to other documents from these repositories.

See https://help.github.com/articles/using-submodules-with-pages/ for more documentation about submodules on GitHub Pages.