### PR TITLE
Add documentation categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ documentation for details.
 
 To build this website locally, it is recommended to use Ruby with [Bundler](http://bundler.io/):
 
+    # make sure to check out any submodules
+    git submodule update --init
     # install the Ruby dependencies locally
     bundle install --path vendor/bundle
     # build and serve the website locally
@@ -15,3 +17,26 @@ To build this website locally, it is recommended to use Ruby with [Bundler](http
 On GitHub Pages, the site is automatically built for each push. Please consult
 [GitHub Help](https://help.github.com/categories/github-pages-basics/) for
 additional information.
+
+## Adding Documentation Pages
+
+Documentation pages are rendered for any files Markdown files (with a YAML
+front matter) in the `_docs` folder. A typical YAML front matter might look
+like this:
+
+    ---
+    title: Title of the Documentation Page
+    nav-index: 4
+    category: Category Name
+    ---
+
+The `title` attribute is mandatory and rendered prominently at the top of each
+document and used as the link title in the navigation menu.
+
+Note that any category referred to in the `category` attribute must also be
+defined in the `docs_categories` collection in `_config.yml`. Otherwise it
+will be put into the default category at the top of the documentation menu.
+
+The `nav-index` of each document defines the order of the document within
+its category. Documents without any `nav-index` will be put at the
+bottom.

--- a/_config.yml
+++ b/_config.yml
@@ -3,10 +3,41 @@ baseurl: ""
 url: "https://strymon-system.github.io/"
 future: false
 
+# DOCUMENTATION
 collections:
   docs:
     output: true
     permalink: /:collection/:name
+
+# categories on the documentation site
+docs_categories:
+  - Strymon Core
+  #- SnailTrail
+  #- Session Reconstruction
+  - Futher Information
+
+# DEFAULT VALUES
+defaults:
+  -
+    scope:
+      path: ""
+      type: docs
+    values:
+      layout: "docs"
+  # we automatically apply the "SnailTrail" category to each file in the "_docs/snailtrail" subfolder
+  -
+    scope:
+      path: "_docs/snailtrail"
+      type: docs
+    values:
+      category: "SnailTrail"
+  # similar for anything about sessionization
+  -
+    scope:
+      path: "_docs/reconstruction"
+      type: docs
+    values:
+      category: "Session Reconstruction"
 
 # THEME-SPECIFIC CONFIGURATION
 theme_settings:

--- a/_docs/codebase-structure.md
+++ b/_docs/codebase-structure.md
@@ -1,7 +1,7 @@
 ---
-layout: docs
 title: Navigating the source code
 nav-index: 5
+category: Strymon Core
 ---
 
 The Strymon open source edition currently contains of a single repository

--- a/_docs/command-line-interface.md
+++ b/_docs/command-line-interface.md
@@ -1,7 +1,7 @@
 ---
-layout: docs
 title: Command-line interface
 nav-index: 3
+category: Strymon Core
 ---
 
 Strymon provides a command-line interface to build and run Timely dataflow

--- a/_docs/getting-started.md
+++ b/_docs/getting-started.md
@@ -1,7 +1,7 @@
 ---
-layout: docs
 title: Getting started
 nav-index: 1
+category: Strymon Core
 ---
 
 ### Get Strymon

--- a/_docs/how-to-contribute.md
+++ b/_docs/how-to-contribute.md
@@ -1,8 +1,8 @@
 ---
-layout: docs
 title: How to contribute
-nav-index: 6
+nav-index: 0
 permalink: /docs/how-to-contribute
+category: Futher Information
 ---
 
 Strymon is currently developed and maintained by an open and friendly [team of researchers at ETH Zürich](http://strymon.systems.ethz.ch/about.html).

--- a/_docs/index.md
+++ b/_docs/index.md
@@ -1,5 +1,4 @@
 ---
-layout: docs
 title: Overview
 permalink: /docs/
 nav-index: 0

--- a/_docs/project-info.md
+++ b/_docs/project-info.md
@@ -1,7 +1,7 @@
 ---
-layout: docs
 title: Project info
-nav-index: 7
+nav-index: 1
+category: "Futher Information"
 ---
 
 - [Mailing list](mailto:strymon-users@lists.inf.ethz.ch)

--- a/_docs/running-the-example.md
+++ b/_docs/running-the-example.md
@@ -1,7 +1,7 @@
 ---
-layout: docs
 title: Running the example
 nav-index: 2
+category: Strymon Core
 ---
 
 The Strymon source code ships with a simple dataflow which generates a

--- a/_docs/runtime-architecture.md
+++ b/_docs/runtime-architecture.md
@@ -1,7 +1,7 @@
 ---
-layout: docs
 title: Run-Time Architecture
 nav-index: 4
+category: Strymon Core
 ---
 
 Strymon is a distributed system that builds on top of the [Rust](https://www.rust-lang.org/en-US/) prototype of [Timely Dataflow](https://github.com/frankmcsherry/timely-dataflow). Timely was first introduced in the [Naiad system](https://dl.acm.org/citation.cfm?id=2522738) and was an attractive option for us due to the following reasons:

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -7,14 +7,44 @@ layout: default
     {% if page.subtitle %}<h2 class="subtitle">{{ page.subtitle }}</h2>{% endif %}
   </header>
   <nav class="side-nav">
+    {% comment %}
+    The following code creates the side navigation for the documentation pages.
+
+    Documents with unexisting or misspelled categories, or no category at all,
+    will be printed first by the first for loop below, i.e. under the title
+    "Documentation".
+
+    Any pages with valid pre-defined categories (i.e. categories defined in
+    `docs_categories` collection the `_config.yml`) will be emitted in the
+    according category in the second for loop. The order of categories is the
+    same as the order defined in the `_config.yml`.
+
+    Note: The `nav-index` of each document defines the order of the document
+    within its category. Documents without any `nav-index` will be put at the
+    bottom.
+    {% endcomment %}
+    <h4>Documentation</h4>
     <ul>
-    {% assign docs = site.docs | sort: 'nav-index' %}
+    {% assign docs = site.docs | sort: 'nav-index', 'last' %}
     {% for doc in docs %}
-    <li {% if page.url == doc.url %}class="active"{% endif %}}>
-      <a href="{{ doc.url | relative_url }}">{{ doc.title }}</a>
-    </li>
+      {% unless site.docs_categories contains doc.category %}
+        <li {% if page.url == doc.url %} class="active" {% endif %} >
+          <a href="{{ doc.url | relative_url }}">{{ doc.title }}</a>
+        </li>
+      {% endunless %}
     {% endfor %}
-    <ul>
+    </ul>
+    {% for category in site.docs_categories %}
+      <h4>{{ category }}</h4>
+      <ul>
+      {% assign docs = site.docs | where: 'category',category | sort: 'nav-index', 'last' %}
+      {% for doc in docs %}
+        <li {% if page.url == doc.url %} class="active" {% endif %} >
+          <a href="{{ doc.url | relative_url }}">{{ doc.title }}</a>
+        </li>
+      {% endfor %}
+      </ul>
+    {% endfor %}
   </nav>
   <section class="post-content">{{ content }}</section>
 </article>


### PR DESCRIPTION
This adds a flat category hierarchie for documentation files found
in the `_docs` folder. The list (and sort order) of categories is
defined as `docs_categories` in the `_config.yml`. Files without
a category (or an invalid category) are put into the default
category at the top of the navigational menu.

This commit additionally sets some default attributes for doc
files, such as the use of the `docs` layout and default
categories for files in certain subfolders.

Signed-off-by: Sebastian Wicki <swicki@inf.ethz.ch>